### PR TITLE
Use url concatenation instead of path concatenation

### DIFF
--- a/helpers-es5.js
+++ b/helpers-es5.js
@@ -16,6 +16,7 @@ var path = require('path'),
     mkdirp = require('mkdirp'),
     Jimp = require('jimp'),
     svg2png = require('svg2png'),
+    url = require('url'),
     File = require('vinyl'),
     Reflect = require('harmony-reflect'),
     NRC = require('node-rest-client').Client,
@@ -46,7 +47,7 @@ var path = require('path'),
         }
 
         function relative(directory) {
-            return path.join(options.path, directory).replace(/\\/g, '/');
+            return url.resolve(options.path, directory).replace(/\\/g, '/');
         }
 
         function print(context, message) {

--- a/helpers.js
+++ b/helpers.js
@@ -12,6 +12,7 @@ const path = require('path'),
     mkdirp = require('mkdirp'),
     Jimp = require('jimp'),
     svg2png = require('svg2png'),
+    url = require('url'),
     File = require('vinyl'),
     Reflect = require('harmony-reflect'),
     NRC = require('node-rest-client').Client,
@@ -42,7 +43,7 @@ const path = require('path'),
         }
 
         function relative (directory) {
-            return path.join(options.path, directory).replace(/\\/g, '/');
+            return url.resolve(options.path, directory).replace(/\\/g, '/');
         }
 
         function print (context, message) {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "tinycolor2": "^1.1.2",
     "to-ico": "^1.1.2",
     "underscore": "^1.8.3",
+    "url": "^0.11.0",
     "vinyl": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Otherwise a `path` of `https://mycdndomain.com/` gets `path.join`-ed to become `https:/mycdndomain.com`, which breaks everything.