### PR TITLE
file.isSymbolic update vinyl package to v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tinycolor2": "^1.1.2",
     "to-ico": "^1.1.2",
     "underscore": "^1.8.3",
-    "vinyl": "^1.1.0"
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.1.18",


### PR DESCRIPTION
#192 

Hi @evilebottnawi, 

I have adjusted the package.json file to reference the new v2.1.0 of vinyl which fixes the issue of error file.isSymbolic within gulp after the release of alpha 3. 

I ran the test which completes successfully. Although I discovered that the tests fail on the data returned from the request function of the helpers-es5.js file with the following message:

```javascript
}) : callback(result.result.error_message);
                                             ^

TypeError: Cannot read property 'result' of undefined
    at /Users/craigpryde/Documents/Websites/favicons/helpers-es5.js:476:46
    at Object.handleResponse (/Users/craigpryde/Documents/Websites/favicons/node_modules/node-rest-client/lib/node-rest-client.js:448:5)
    at Object.handleEnd (/Users/craigpryde/Documents/Websites/favicons/node_modules/node-rest-client/lib/node-rest-client.js:421:10)
    at IncomingMessage.<anonymous> (/Users/craigpryde/Documents/Websites/favicons/node_modules/node-rest-client/lib/node-rest-client.js:587:13)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1056:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

This was happening in the original master version that I cloned without making any updates. Unfortunately, i don't have the time to investigate the realfavicongenerator API to assist in debugging this other issue.

let me know your thoughts

Cheers 
Craig 