### PR TITLE
Accept an array of file buffers as source

### DIFF
--- a/helpers-es5.js
+++ b/helpers-es5.js
@@ -143,7 +143,15 @@ var path = require('path'),
                         return callback(null, sourceset);
                     } else if (Array.isArray(_source)) {
                         async.each(_source, function (file, cb) {
-                            return readFile(file, function (error, buffer) {
+                            if (Buffer.isBuffer(file)) {
+                                sourceset.push({
+                                    size: sizeOf(file),
+                                    file: file
+                                });
+                                return cb(null);
+                            }
+
+                            readFile(file, function (error, buffer) {
                                 if (error) {
                                     return cb(error);
                                 }

--- a/helpers.js
+++ b/helpers.js
@@ -135,7 +135,15 @@ const path = require('path'),
                         sourceset = [{ size: sizeOf(source), file: source }];
                         return callback(null, sourceset);
                     } else if (Array.isArray(source)) {
-                        async.each(source, (file, cb) =>
+                        async.each(source, (file, cb) => {
+                            if (Buffer.isBuffer(file)) {
+                                sourceset.push({
+                                    size: sizeOf(file),
+                                    file
+                                });
+                                return cb(null);
+                            }
+                            
                             readFile(file, (error, buffer) => {
                                 if (error) {
                                     return cb(error);
@@ -146,9 +154,9 @@ const path = require('path'),
                                     file: buffer
                                 });
                                 cb(null);
-                            }),
-                            (error) =>
-                                callback(error || sourceset.length ? null : 'Favicons source is invalid', sourceset)
+                            });
+                        }, (error) =>
+                            callback(error || sourceset.length ? null : 'Favicons source is invalid', sourceset)
                         );
                     } else if (typeof source === 'string') {
                         readFile(source, (error, buffer) => {


### PR DESCRIPTION
Currently the source can be a string, buffer, or Array\<string\>. This adds support for Array\<buffer\> as well.